### PR TITLE
add meeting_type_id

### DIFF
--- a/web/models/meeting_date.ex
+++ b/web/models/meeting_date.ex
@@ -15,7 +15,7 @@ defmodule Meetings.MeetingDate do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:month, :day, :year])
-    |> validate_required([:month, :day, :year])
+    |> cast(params, [:meeting_type_id, :month, :day, :year])
+    |> validate_required([:meeting_type_id, :month, :day, :year])
   end
 end

--- a/web/models/meeting_extra.ex
+++ b/web/models/meeting_extra.ex
@@ -14,7 +14,7 @@ defmodule Meetings.MeetingExtra do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:field, :value])
-    |> validate_required([:field, :value])
+    |> cast(params, [:meeting_type_id, :field, :value])
+    |> validate_required([:meeting_type_id, :field, :value])
   end
 end

--- a/web/templates/meeting/show.html.eex
+++ b/web/templates/meeting/show.html.eex
@@ -2,8 +2,8 @@
 
 <ul>
   <li>
-    <strong>Type:</strong>
-    <a href="/meeting_types/<%= @meeting.id %>"><%= @meeting.type %></a>
+    <strong><a href="/meeting_types/<%= @meeting.id %>">Type</a>:</strong>
+    <%= @meeting.type %>
   </li>
 
   <li>
@@ -54,8 +54,9 @@
 
 <ul>
 <%= for extra <- @meeting.meeting_extras do %>
-  <li><strong><%= extra.field %>:</strong>
-    <a href="/meeting_extras/<%= extra.id %>"><%= extra.value %></a>
+  <li>
+    <strong><a href="/meeting_extras/<%= extra.id %>"><%= extra.field %></a>:</strong>
+    <%= extra.value %></a>
   </li>
 <% end %>
 </ul>

--- a/web/templates/meeting_date/form.html.eex
+++ b/web/templates/meeting_date/form.html.eex
@@ -5,6 +5,12 @@
     </div>
   <% end %>
 
+   <div class="form-group">
+    <%= label f, :meeting_type_id, class: "control-label" %>
+    <%= number_input f, :meeting_type_id, class: "form-control" %>
+    <%= error_tag f, :id %>
+  </div>
+
   <div class="form-group">
     <%= label f, :month, class: "control-label" %>
     <%= number_input f, :month, class: "form-control" %>

--- a/web/templates/meeting_extra/form.html.eex
+++ b/web/templates/meeting_extra/form.html.eex
@@ -6,6 +6,12 @@
   <% end %>
 
   <div class="form-group">
+    <%= label f, :meeting_type_id, class: "control-label" %>
+    <%= number_input f, :meeting_type_id, class: "form-control" %>
+    <%= error_tag f, :id %>
+  </div>
+
+  <div class="form-group">
     <%= label f, :field, class: "control-label" %>
     <%= text_input f, :field, class: "form-control" %>
     <%= error_tag f, :field %>


### PR DESCRIPTION
There was no way to add a date or extra field through and link it to the meeting type through website. This adds a meeting_type_id field to changeset and forms so at least the linking can be entered. if you know the id of the meeting type.