### PR TITLE
change footer element to fixed instead of absolute

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -35,8 +35,11 @@
 
 
 footer {
-	position: absolute;
-	bottom: 0;
-	width: 100%;
-	text-align: center;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: #efefef;
+  text-align: center;
 }

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -39,6 +39,7 @@
     </div> <!-- /container -->
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
+  
   <footer>
     <p>
       Supported by <a href="http://openwichita.com/" target="_blank">Open Wichita</a>.


### PR DESCRIPTION
This will at least make the meeting list look better by not having the footer stuck in the middle of a meeting when you scroll past it.

The real issue is that while the `<footer>` element is at the bottom and outside of any tag on the app.html.eex file, it somehow gets rendered to be inside the body when it is served. I don't know where to look for whatever is doing that, but this is a "fix" in the meantime.