### PR TITLE
Fix iCalendar export for single events

### DIFF
--- a/web/controllers/meeting_controller.ex
+++ b/web/controllers/meeting_controller.ex
@@ -28,10 +28,17 @@ defmodule Meetings.MeetingController do
 
   def show(conn, %{"id" => id} = params) do
     meeting_data = Meeting.get(id)
+    render(conn, "show.html", meeting: meeting_data)
+  end
+
+  def show_date(conn, %{"type_id" => type_id, "date_id" => date_id} = params) do
+    meeting = Meeting.from_meeting_date(date_id)
 
     case Map.get(params, "format") do
-      "ics" -> ical_response_meetings(conn, [meeting_data])
-      _ -> render(conn, "show.html", meeting: meeting_data)
+      "ics" -> ical_response_meetings(conn, [meeting])
+      # TODO: this doesn't actually work at the moment, but probably useful to
+      # have a display page for a single meeting at some point
+      _ -> render(conn, "show.html", meeting: meeting)
     end
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -41,6 +41,7 @@ defmodule Meetings.Router do
     get "/meetings", MeetingController, :index
     get "/meetings/types", MeetingController, :types
     get "/meetings/:id", MeetingController, :show
+    get "/meetings/:type_id/date/:date_id", MeetingController, :show_date
   end
 
   scope "/", Meetings do

--- a/web/templates/meeting/index.html.eex
+++ b/web/templates/meeting/index.html.eex
@@ -16,7 +16,7 @@
     <%= for meeting <- @meetings do %>
       <tr>
         <td>
-          <h3><a href="/meetings/<%= meeting.id %>"><%= meeting.title %></a></h3>
+          <h3><a href="/meetings/<%= meeting.type_id %>"><%= meeting.title %></a></h3>
           <p>
             <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <%= DateTime.to_date(meeting.date) %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= DateTime.to_time(meeting.date) %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= meeting.duration %>
           </p>
@@ -25,7 +25,7 @@
           </p>
         </td>
         <td>
-          <a class="btn btn-default btn-xs" href="/meetings/<%= meeting.id %>/?format=ics">Add</a>
+          <a class="btn btn-default btn-xs" href="/meetings/<%= meeting.type_id %>/date/<%= meeting.date_id %>/?format=ics">Add</a>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
There's probably a better way to consolidate constructing a `Meeting`
out of a `MeetingType` and `MeetingDate`, but this is quick for now.

Resolves #42