### PR TITLE
Date and time formatting

### DIFF
--- a/web/templates/meeting/index.html.eex
+++ b/web/templates/meeting/index.html.eex
@@ -18,7 +18,7 @@
         <td>
           <h3><a href="/meetings/<%= meeting.type_id %>"><%= meeting.title %></a></h3>
           <p>
-            <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <%= DateTime.to_date(meeting.date) %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= DateTime.to_time(meeting.date) %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= meeting.duration %>
+            <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <%= Timex.format!(meeting.date, "{Mshort}. {D}, {YYYY}") %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= Timex.format!(meeting.date, "{h12}:{m} {AM}") %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= meeting.duration %>
           </p>
           <p>
             <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span> <a href="http://maps.google.com?q=<%= meeting.location %>" target="_blank" rel="noreferrer noopener"><%= meeting.location %></a>

--- a/web/templates/meeting/index.html.eex
+++ b/web/templates/meeting/index.html.eex
@@ -18,7 +18,8 @@
         <td>
           <h3><a href="/meetings/<%= meeting.type_id %>"><%= meeting.title %></a></h3>
           <p>
-            <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <%= Timex.format!(meeting.date, "{Mshort}. {D}, {YYYY}") %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= Timex.format!(meeting.date, "{h12}:{m} {AM}") %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= meeting.duration %>
+            <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <%= Timex.format!(meeting.date, "{Mshort}. {D}, {YYYY}") %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= Timex.format!(meeting.date, "{h12}:{m} {AM}") %> &nbsp; <span class="glyphicon glyphicon-time" aria-hidden="true"></span> 
+            <%= Timex.Format.Duration.Formatter.format(Timex.Duration.from_minutes(meeting.duration), :humanized) %>
           </p>
           <p>
             <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span> <a href="http://maps.google.com?q=<%= meeting.location %>" target="_blank" rel="noreferrer noopener"><%= meeting.location %></a>

--- a/web/templates/meeting/show.html.eex
+++ b/web/templates/meeting/show.html.eex
@@ -27,7 +27,7 @@
   </li>
 
   <li>
-    <strong>Hour:</strong>
+    <strong>Time:</strong>
     <%= @meeting.hour %>
   </li>
 
@@ -38,7 +38,7 @@
 
   <li>
     <strong>Duration:</strong>
-    <%= @meeting.duration %>
+    <%= Timex.Format.Duration.Formatter.format(Timex.Duration.from_minutes(@meeting.duration), :humanized) %>
   </li>
 
   <li>
@@ -70,12 +70,10 @@
 
 <ul>
 <%= for date <- @meeting.meeting_dates do %>
-  <li><a href="/meeting_dates/<%= date.id %>"><%= date.month %>/<%= date.day %>, <%= date.year %></a>
+  <li><a href="/meeting_dates/<%= date.id %>"><%= Timex.format!(date, "{Mshort}. {D}, {YYYY}") %></a>
   </li>
 <% end %>
 </ul>
-
-
 
 <%= link "Edit", to: meeting_type_path(@conn, :edit, @meeting) %>
 &nbsp;

--- a/web/templates/meeting/show.html.eex
+++ b/web/templates/meeting/show.html.eex
@@ -27,7 +27,7 @@
   </li>
 
   <li>
-    <strong>Time:</strong>
+    <strong>Hour:</strong>
     <%= @meeting.hour %>
   </li>
 


### PR DESCRIPTION
Addresses #44 .

This doesn't exactly match the requested formatting for duration. Timex has an option to display durations as "1 hour, 45 minutes" for example. I was afraid that displaying it like "1:45" would make it look like the meeting was taking place at 1:45 p.m. Even though there's a separate time field, they aren't labeled explicitly on the meetings list. 